### PR TITLE
Fix long click to paste not working on first run

### DIFF
--- a/src/com/android/calculator2/CalculatorFormula.java
+++ b/src/com/android/calculator2/CalculatorFormula.java
@@ -124,7 +124,7 @@ public class CalculatorFormula extends AlignedTextView implements MenuItem.OnMen
         super.onAttachedToWindow();
 
         mClipboardManager.addPrimaryClipChangedListener(this);
-        onPrimaryClipChanged();
+        post(this::onPrimaryClipChanged);
     }
 
     @Override


### PR DESCRIPTION
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/5358

The `onPrimaryClipChanged` was being fired before the UI was fully attached, causing it to miss the clipboard's actual content.